### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "webflo/drupal-core-require-dev": "*"
     },
     "require": {
-        "behat/mink": "1.8.0 | 1.7.1.1 | 1.7.x-dev",
+        "behat/mink": "1.7.1 | 1.7.x-dev",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "1.4.0 | 1.3.1.1 | 1.3.x-dev",
         "composer/composer": "^1.9.1",


### PR DESCRIPTION
https://packagist.org/packages/behat/mink
Packages behat/mink 1.8.0 and 1.7.1.1 don't exist, this is forcing the 1.7.x-dev.

Using a dev version cause conflict when composer is configured with "minimum-stability: stable".

Why are we using specifics version for behat/mink ? Couldn't we expect to use "^1.7.1" ?