### PR TITLE
allow symfony/filesystem 5.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/css-selector": "^4.4",
         "symfony/dom-crawler": "^4.4 !=4.4.5",
         "symfony/error-handler": "^4.4",
-        "symfony/filesystem": "^4.4",
+        "symfony/filesystem": "^4.4 || ^5.4",
         "symfony/finder": "^4.4",
         "symfony/lock": "^4.4",
         "symfony/phpunit-bridge": "^5.4",


### PR DESCRIPTION
Drush 11.x-dev requires symfony/filesystem ^5.4. Right now, core-dev is blocking this for 9.x. see https://github.com/drush-ops/drush/blob/11.x/composer.json#L48