### PR TITLE
Remove deprecated vendor friends of behat, and make it compatible with drupalextension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "composer/composer": "^2.2.12",
         "drupal/coder": "^8.3.10",
         "easyrdf/easyrdf": "^0.9 || ^1.0",
-        "friends-of-behat/mink-browserkit-driver": "^1.4",
+        "behat/mink-browserkit-driver": "^2.1",
         "instaclick/php-webdriver": "^1.4.1",
         "justinrainbow/json-schema": "^5.2",
         "mikey179/vfsstream": "^1.6.11",


### PR DESCRIPTION
Friends of behat was forked to be compatible with higher versions of Symfony and with PHP 8, now, the latest version of "behat/mink-browserkit-driver": "^2.1", is compatible with it, so is not necessary to require this package anymore.

Also, this makes to be incompatible with drupalextension see the issue https://github.com/jhedstrom/drupalextension/issues/637

On drupal 10, already is required "behat/mink-browserkit-driver": "^2.1", so can be replaced https://github.com/drupal/core-dev/blob/10.0.x/composer.json